### PR TITLE
CS12rc6 upgrade of OSC 11.1.4 leaves OSC's runsvdir tree running

### DIFF
--- a/config/projects/chef-server.rb
+++ b/config/projects/chef-server.rb
@@ -28,6 +28,7 @@ dependency "openresty"
 dependency "redis-rb" # gem for interacting with redis
 dependency "openresty-lpeg"  # lua-based routing
 dependency "runit"
+dependency "private-chef-extras" # extra miscellaneous files used throughout the install
 
 # the backend
 dependency "postgresql92"

--- a/config/software/private-chef-extras.rb
+++ b/config/software/private-chef-extras.rb
@@ -1,0 +1,10 @@
+name "private-chef-extras"
+
+dependency "rsync"
+
+source :path => File.expand_path("files/private-chef-extras", Config.project_root)
+
+build do
+  command "mkdir -p #{install_dir}/embedded/extra"
+  command "#{install_dir}/embedded/bin/rsync -a ./ #{install_dir}/embedded/extra"
+end

--- a/files/private-chef-ctl-commands/open_source_chef12_upgrade.rb
+++ b/files/private-chef-ctl-commands/open_source_chef12_upgrade.rb
@@ -405,7 +405,16 @@ EOF
   def stop_chef11
     log 'Ensuring open source Chef 11 server is stopped'
     msg = "Unable to stop open souce Chef 11 server, which is needed to complete the upgrade"
-    status = run_command("/opt/chef-server/bin/chef-server-ctl stop")
+    status = run_command("ln -sf /opt/chef-server/bin/chef-server-ctl /usr/bin/chef-server-ctl")
+    check_status(status, msg)
+    status = run_command("initctl stop chef-server-runsvdir")
+    check_status(status, msg)
+    status = run_command("ln -sf /opt/opscode/bin/chef-server-ctl /usr/bin/chef-server-ctl")
+    check_status(status, msg)
+    FileUtils.rm_f("/etc/init/chef-server-runsvdir.conf") if File.exists?("/etc/init/chef-server-runsvdir.conf")
+    status = run_command("egrep -v '/opt/chef-server/embedded/bin/runsvdir-start' /etc/inittab > /etc/inittab.new && mv /etc/inittab.new /etc/inittab") if File.exists?("/etc/inittab")
+    check_status(status, msg)
+    status = run_command("kill -HUP 1")
     check_status(status, msg)
   end
 

--- a/files/private-chef-extras/chef-server-runsvdir.patched.conf
+++ b/files/private-chef-extras/chef-server-runsvdir.patched.conf
@@ -1,0 +1,16 @@
+start on runlevel [2345]
+stop on shutdown
+respawn
+pre-stop script
+   # To avoid Chef service processes from being orphaned,
+   # we need to ensure everything is stopped before we kill our
+   # runsvdir process.
+   /opt/chef-server/bin/chef-server-ctl stop
+end script
+post-stop script
+   # To avoid stomping on runsv's owned by a different runsvdir
+   # process, kill any runsv process that has been orphaned, and is
+   # now owned by init (process 1).
+   pkill -HUP -P 1 runsv$
+end script
+exec /opt/chef-server/embedded/bin/runsvdir-start


### PR DESCRIPTION
Ref: https://github.com/opscode/chef-server/issues/25

This is the cleanest way to properly shutdown the Open Source Chef
Server runsvdir tree and ensure that its init script is removed.

I tested this and it works for me.