### PR TITLE
Add the missing error_exit function to ha_backend_storage

### DIFF
--- a/files/private-chef-cookbooks/chef-ha-drbd/templates/default/ha_backend_storage_drbd.erb
+++ b/files/private-chef-cookbooks/chef-ha-drbd/templates/default/ha_backend_storage_drbd.erb
@@ -1,10 +1,18 @@
 #!/bin/bash
 # vim: sw=2 sts=2 et ts=8:
 LOGNAME=/var/log/opscode/keepalived/cluster.log
+
 function log_me
 {
   echo $1
   echo "$(date -R): ${1}" >> $LOGNAME
+}
+
+function error_exit
+{
+  log_me "$1"
+  echo "${PROGNAME}: ${1:-"Unknown Error"}" 1>&2
+  exit 1
 }
 
 # 10 * SVWAIT


### PR DESCRIPTION
otherwise hilarious things happen when tries are exhausted:

```
Tue, 09 Dec 2014 20:39:58 +0000: Attempting to become DRBD secondary - attempts left 1
/var/opt/opscode/drbd/data is a mountpoint
/var/opt/opscode/drbd/data: 29583c 29586c 29587c 29588c 29589c 29590c
umount2: Device or resource busy
umount: /var/opt/opscode/drbd/data: device is busy.
        (In some cases useful info about processes that use
         the device is found by lsof(8) or fuser(1))
umount2: Device or resource busy
0: State change failed: (-12) Device is held open by someone
Command 'drbdsetup-84 secondary 0' terminated with exit code 11
/var/opt/opscode/keepalived/bin/ha_backend_storage: line 40: error_exit: command not found
Attempting to become DRBD secondary - attempts left 0
Tue, 09 Dec 2014 20:39:59 +0000: Attempting to become DRBD secondary - attempts left 0
/var/opt/opscode/drbd/data is a mountpoint
/var/opt/opscode/drbd/data: 29603c 29607c 29608c 29609c 29610c 29611c
umount2: Device or resource busy
umount: /var/opt/opscode/drbd/data: device is busy.
        (In some cases useful info about processes that use
         the device is found by lsof(8) or fuser(1))
umount2: Device or resource busy
0: State change failed: (-12) Device is held open by someone
Command 'drbdsetup-84 secondary 0' terminated with exit code 11
Attempting to become DRBD secondary - attempts left -1
Tue, 09 Dec 2014 20:40:00 +0000: Attempting to become DRBD secondary - attempts left -1
... ad nauseum...
```

because of this
```
/var/opt/opscode/keepalived/bin/ha_backend_storage: line 40: error_exit: command not found
```