### PR TITLE
Use the latest 11.x chef-client

### DIFF
--- a/config/projects/chef-server.rb
+++ b/config/projects/chef-server.rb
@@ -31,6 +31,7 @@ override :berkshelf2, version: "2.0.18"
 override :rabbitmq, version: "3.3.4"
 override :erlang, version: "R16B03-1"
 override :'omnibus-ctl', version: "0.3.1"
+override :'chef-gem', version: "11.16.4"
 
 # creates required build directories
 dependency "preparation"


### PR DESCRIPTION
After the update to omnibus 4 the `ffi-yajl` gem has been updated to a new major version which results in deprecation warnings when most `chef-server-ctl` commands are used.

```
the ffi-yajl and yajl-ruby gems have incompatible C libyajl libs and should not be loaded in the same Ruby VM
falling back to ffi which might work (or might not, no promises)
ffi-yajl/json_gem is deprecated, these monkeypatches will be dropped shortly
```

If we bump the chef-client version to the latest 11 stable version these deprecation warnings go away.