### PR TITLE
Sanitize PERL5LIB when running sqitch

### DIFF
--- a/files/private-chef-cookbooks/private-chef/recipes/bifrost_database.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/bifrost_database.rb
@@ -44,6 +44,9 @@ execute "bifrost_schema" do
            deploy --verify
   EOM
   user node['private_chef']['postgresql']['username']
+  # Clear PERL5LIB to ensure sqitch only uses omnibus's perl
+  # installation
+  environment "PERL5LIB" => ""
   # If sqitch is deploying the first time, it'll return 0 on
   # success.  If it's running a second time and ends up deploying
   # nothing (since we've already deployed all changesets), it'll

--- a/files/private-chef-cookbooks/private-chef/recipes/erchef_database.rb
+++ b/files/private-chef-cookbooks/private-chef/recipes/erchef_database.rb
@@ -16,6 +16,9 @@ execute "chef-server-schema" do
   # OSC schema is a dependency of the EC schema, and managed by it
   cwd "/opt/opscode/embedded/service/enterprise-chef-server-schema/deps/chef-server-schema"
   user node['private_chef']['postgresql']['username']
+  # Clear PERL5LIB to ensure sqitch only uses omnibus's perl
+  # installation
+  environment "PERL5LIB" => ""
   returns [0,1]
   action :nothing
   notifies :run, "execute[enterprise-chef-server-schema]", :immediately
@@ -25,6 +28,9 @@ execute "enterprise-chef-server-schema" do
   command "sqitch --db-name opscode_chef deploy --verify"
   cwd "/opt/opscode/embedded/service/enterprise-chef-server-schema"
   user node['private_chef']['postgresql']['username']
+  # Clear PERL5LIB to ensure sqitch only uses omnibus's perl
+  # installation
+  environment "PERL5LIB" => ""
   returns [0,1]
   action :nothing
 end


### PR DESCRIPTION
When PERL5LIB is set to path, sqitch may use libraries from that path
and fail.  Sanitizing the environment avoids this error.