### PR TITLE
Set oc-chef-pedant to 1.0.69

### DIFF
--- a/config/software/oc-chef-pedant.rb
+++ b/config/software/oc-chef-pedant.rb
@@ -15,7 +15,7 @@
 #
 
 name "oc-chef-pedant"
-default_version "1.0.68"
+default_version "1.0.69"
 
 source git: "git@github.com:opscode/oc-chef-pedant.git"
 


### PR DESCRIPTION
Bumps pedant to the latest release, which is warning free on RSpec 2.99. A similar (but not identical, because rebase) branch passed Ci as chef-server-12-test build 484.