### PR TITLE
Made DEV_PLATFORM and environment variable respected by makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 #
 # e.g., 'make -f build_node.mk $TARGET'
 
-DEV_PLATFORM=ubuntu-1004
+DEV_PLATFORM ?= ubuntu-1004
 DEV_PROJECT=opscode-omnibus
 
 .DEFAULT_GOAL=dev

--- a/README.md
+++ b/README.md
@@ -85,7 +85,15 @@ $ bin/omnibus help
 
 Makefile instructions
 ---------------------
-Top level make targets:
+
+You can change the dev platform (anywhere it says "ubuntu 1004" below)
+to one of your choosing by setting the environment variable
+`DEV_PLATFORM`
+
+**Note:** Any `make` or `kitchen` commands expect `opscode\omnibus`
+  and `opscode\omnibus-software` to be cloned from github in `..`
+
+#### Top level make targets:
 
 `$ make dev` converges the dev platform (ubuntu 1004)
 


### PR DESCRIPTION
If you have a `DEV_PLATFORM` set in your environment, it uses that instead of `ubuntu-1004` for the `make dev*` targets