### PR TITLE
Return knife-opc's exit status in wrap-knife-opc commands

### DIFF
--- a/files/private-chef-ctl-commands/wrap-knife-opc.rb
+++ b/files/private-chef-ctl-commands/wrap-knife-opc.rb
@@ -27,6 +27,7 @@ cmds.each do |cmd, args|
   opc_noun = args[1]
   description = args[2]
   add_command_under_category cmd, "organization-and-user-management", description, 2 do
-    run_command("#{knife_cmd} opc #{opc_noun} #{opc_cmd} #{cmd_args.join(' ')} -c #{knife_config}")
+    status = run_command("#{knife_cmd} opc #{opc_noun} #{opc_cmd} #{cmd_args.join(' ')} -c #{knife_config}")
+    exit status.exitstatus
   end
 end


### PR DESCRIPTION
Knife-opc typically produces a non-zero exit status on failure.
Ensure that this is reflected in chef-server-ctl's exit status.

Fixes chef-server#65